### PR TITLE
fix : delta calc rounding error

### DIFF
--- a/src/interest.sol
+++ b/src/interest.sol
@@ -29,7 +29,6 @@ contract Interest is Math {
         require(chi != 0);
         // instead of a interestBearingAmount we use a accumulated interest rate index (chi)
         uint updatedChi = chargeInterest(chi ,ratePerSecond, lastUpdated);
-        uint chi_ = safeSub(updatedChi, chi);
         return (updatedChi, safeSub(rmul(updatedChi, pie), rmul(chi, pie)));
     }
 

--- a/src/interest.sol
+++ b/src/interest.sol
@@ -30,7 +30,7 @@ contract Interest is Math {
         // instead of a interestBearingAmount we use a accumulated interest rate index (chi)
         uint updatedChi = chargeInterest(chi ,ratePerSecond, lastUpdated);
         uint chi_ = safeSub(updatedChi, chi);
-        return (updatedChi, rmul(pie, chi_));
+        return (updatedChi, safeSub(rmul(updatedChi, pie), rmul(chi, pie)));
     }
 
     // @notice This function charge interest on a interestBearingAmount

--- a/src/test/interest.t.sol
+++ b/src/test/interest.t.sol
@@ -107,4 +107,17 @@ contract InterestTest is Interest, DSTest{
         assertEq(delta_, 5000000000000000000);
         assertEq(newAmount - oldAmount, delta_);
     }
+
+    function testCompoundingDeltaAmount() public {
+        uint amount = 10 ether;
+        uint chi = 1000000564701133626865910626; // 5% day
+        uint pie = toPie(chi, amount);
+
+        // random chi increase
+        uint last = now;
+        hevm.warp(now + 3 days + 123 seconds);
+        (uint latestChi, uint deltaAmount) = compounding(chi, chi, last ,pie);
+
+        assertEq(toAmount(latestChi, pie), safeAdd(amount, deltaAmount));
+    }
 }

--- a/src/test/interest.t.sol
+++ b/src/test/interest.t.sol
@@ -118,6 +118,6 @@ contract InterestTest is Interest, DSTest{
         hevm.warp(now + 3 days + 123 seconds);
         (uint latestChi, uint deltaAmount) = compounding(chi, chi, last ,pie);
 
-        assertEq(toAmount(latestChi, pie), safeAdd(amount, deltaAmount));
+        assertEq(toAmount(latestChi, pie) -  toAmount(chi, pie), deltaAmount);
     }
 }


### PR DESCRIPTION
**Tinlake Debt Calculation**
```javascript
debt = pie * chi 
```
the compounding method calculates the latest `chi` together with the delta amount.

**Problem**
the current implementation doesn't guarantee always the following: 

```javascript
pie * latestChi - pie * chi == (latestChi-chi) * pie
``` 
Obviously, in mathematical terms this is correct. It is easy to transfer the left side to the right or vis-versa.

**Why**
Because we use `rmul` for multiplication.
```javascript
rmul(pie, latestChi) - rmul(pie, chi) == rmul(latestChi-chi, pie)
``` 
rmul performs integer division `safeMul(x, y) / ONE;` which cuts of some decimals.
One the left side this is happening twice on the right side it happens only once.

**Context to Tinlake Loan Repay Bug**
We use the `delta` to increase the total debt in Tinlake. (right side of the equation)

If a loan is repaid the total debt will be decreased. The loan repayment amount is calculated with `pie * latestChi` for full repayment.  This caused differences between total debt and the sum of all loan debts
